### PR TITLE
Use git tags to derive rpm version.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,11 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src
 EXTRA_DIST = autogen.sh
+REPO_TAG=$(shell git describe --tags --match "v*" 2>/dev/null | cut -b 2-)
+REPO_TAGFMT=$(shell echo ${REPO_TAG} | sed 's/-g/-/')
+REPO_VER=$(shell echo ${REPO_TAGFMT} | cut -d '-' -f 1)
+REPO_REL=$(shell echo ${REPO_TAGFMT} | cut -d '-' -f 2,3 | sed 's/-/_/')
+REPO_COMMITS=$(shell git log --oneline | wc -l)
 
 rpmdir=$(abs_builddir)/rpms
 
@@ -12,7 +17,14 @@ rpm: dist
 	mkdir -p $(rpmdir)/BUILD
 	mkdir -p $(rpmdir)/BUILDROOT
 	cp $(distdir).tar.gz $(rpmdir)/SOURCES
-	rpmbuild -ba -D "_topdir $(rpmdir)" $(top_srcdir)/treadmill-bind.spec
+	REPO_VER=$(REPO_VER) && REPO_REL=$(REPO_REL) && \
+	rpmbuild -ba \
+           -D "_topdir $(rpmdir)" \
+		   -D "_version $${REPO_VER:=0.0}" \
+		   -D "_release $${REPO_REL:=$(REPO_COMMITS)}" \
+           $(top_srcdir)/treadmill-bind.spec
+
+
 
 install_rpm:
 	[ ! -z $(rpm_install_dir) ] || echo must run make rpm_install_dir=...

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(treadmill-bind, 5.1, andreikeis@noreply.users.github.com)
+AC_INIT(treadmill-bind, m4_esyscmd_s([git describe --tags HEAD --long --match "v*" 2>/dev/null > /dev/null; if [ $? == 0 ]; then git describe --tags HEAD --long --match "v*" 2>/dev/null | cut -b 2- | cut -d '-' -f 1; else echo 0.0; fi]), andreikeis@noreply.users.github.com)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_SRCDIR(src/bind_preload.c)

--- a/treadmill-bind.spec
+++ b/treadmill-bind.spec
@@ -1,6 +1,6 @@
 Name:           treadmill-bind
-Version:        5.1
-Release:        2%{?dist}
+Version:        %{_version} 
+Release:        %{_release}%{?dist}
 Summary:        Treadmill bind preload shared library.
 
 License:        Apache 2.0
@@ -17,7 +17,7 @@ Treadmill bind preload library.
 
 
 %build
-%configure
+%configure --prefix=/ --libdir=/lib64
 make %{?_smp_mflags}
 
 
@@ -28,11 +28,7 @@ make install DESTDIR=$RPM_BUILD_ROOT/opt/treadmill-bind
 
 %files
 %defattr(-,root,root,-)
-/opt/treadmill-bind/%{_libdir}/libtreadmill_bind_preload.a
-/opt/treadmill-bind/%{_libdir}/libtreadmill_bind_preload.la
-/opt/treadmill-bind/%{_libdir}/libtreadmill_bind_preload.so
-/opt/treadmill-bind/%{_libdir}/libtreadmill_bind_preload.so.0
-/opt/treadmill-bind/%{_libdir}/libtreadmill_bind_preload.so.0.0.0
+/opt/treadmill-bind/*
 %doc
 
 


### PR DESCRIPTION
- Use v<release> tag to derive rpm version.
- If tag is not found, version defaults to 0.0 and release to # of
  commits.